### PR TITLE
Add sigmoid at test time for stackex example

### DIFF
--- a/examples/gnn.py
+++ b/examples/gnn.py
@@ -220,6 +220,10 @@ def test(loader: NodeLoader) -> np.ndarray:
             batch.num_sampled_nodes_dict,
             batch.num_sampled_edges_dict,
         )
+
+        if task.task_type == TaskType.BINARY_CLASSIFICATION:
+            pred = torch.sigmoid(pred)
+
         pred = pred.view(-1) if pred.size(1) == 1 else pred
         pred_list.append(pred.detach().cpu())
     return torch.cat(pred_list, dim=0).numpy()


### PR DESCRIPTION
This PR makes a small change to the GNN example script to apply sigmoid activation to the outputs when testing.

When running for binary classification tasks, the previous version passes raw logits to `task.evaluate`, but the metrics seem to expect sigmoid-activated outputs as they threshold at 0.5.
