### PR TITLE
Fix `to_unix_time` for pandas v2

### DIFF
--- a/relbench/datasets/stackex.py
+++ b/relbench/datasets/stackex.py
@@ -5,7 +5,7 @@ import pooch
 
 from relbench.data import Database, RelBenchDataset, Table
 from relbench.tasks.stackex import EngageTask, VotesTask
-from relbench.utils import to_unix_time, unzip_processor
+from relbench.utils import unzip_processor
 
 
 class StackExDataset(RelBenchDataset):
@@ -65,15 +65,15 @@ class StackExDataset(RelBenchDataset):
         comments.drop(columns=["Score"], inplace=True)
         votes.drop(columns=["BountyAmount"], inplace=True)
 
-        ## change time column to unix time
-        comments["CreationDate"] = to_unix_time(comments["CreationDate"])
-        badges["Date"] = to_unix_time(badges["Date"])
-        postLinks["CreationDate"] = to_unix_time(postLinks["CreationDate"])
+        ## change time column to pd timestamp series
+        comments["CreationDate"] =pd.to_datetime(comments["CreationDate"])
+        badges["Date"] =pd.to_datetime(badges["Date"])
+        postLinks["CreationDate"] =pd.to_datetime(postLinks["CreationDate"])
 
-        postHistory["CreationDate"] = to_unix_time(postHistory["CreationDate"])
-        votes["CreationDate"] = to_unix_time(votes["CreationDate"])
-        posts["CreationDate"] = to_unix_time(posts["CreationDate"])
-        users["CreationDate"] = to_unix_time(users["CreationDate"])
+        postHistory["CreationDate"] =pd.to_datetime(postHistory["CreationDate"])
+        votes["CreationDate"] =pd.to_datetime(votes["CreationDate"])
+        posts["CreationDate"] =pd.to_datetime(posts["CreationDate"])
+        users["CreationDate"] =pd.to_datetime(users["CreationDate"])
 
         tables = {}
 

--- a/relbench/datasets/stackex.py
+++ b/relbench/datasets/stackex.py
@@ -66,14 +66,14 @@ class StackExDataset(RelBenchDataset):
         votes.drop(columns=["BountyAmount"], inplace=True)
 
         ## change time column to pd timestamp series
-        comments["CreationDate"] =pd.to_datetime(comments["CreationDate"])
-        badges["Date"] =pd.to_datetime(badges["Date"])
-        postLinks["CreationDate"] =pd.to_datetime(postLinks["CreationDate"])
+        comments["CreationDate"] = pd.to_datetime(comments["CreationDate"])
+        badges["Date"] = pd.to_datetime(badges["Date"])
+        postLinks["CreationDate"] = pd.to_datetime(postLinks["CreationDate"])
 
-        postHistory["CreationDate"] =pd.to_datetime(postHistory["CreationDate"])
-        votes["CreationDate"] =pd.to_datetime(votes["CreationDate"])
-        posts["CreationDate"] =pd.to_datetime(posts["CreationDate"])
-        users["CreationDate"] =pd.to_datetime(users["CreationDate"])
+        postHistory["CreationDate"] = pd.to_datetime(postHistory["CreationDate"])
+        votes["CreationDate"] = pd.to_datetime(votes["CreationDate"])
+        posts["CreationDate"] = pd.to_datetime(posts["CreationDate"])
+        users["CreationDate"] = pd.to_datetime(users["CreationDate"])
 
         tables = {}
 

--- a/relbench/external/graph.py
+++ b/relbench/external/graph.py
@@ -20,7 +20,11 @@ from relbench.data.task import Task
 def to_unix_time(ser: pd.Series) -> Tensor:
     r"""Converts a :class:`pandas.Timestamp` series to UNIX timestamp
     (in seconds)."""
-    return torch.from_numpy(ser.astype(int).values) // 10**9
+    assert ser.dtype in [np.dtype('datetime64[s]'), np.dtype('datetime64[ns]')]
+    unix_time = torch.from_numpy(ser.astype(int).values)
+    if ser.dtype == np.dtype('datetime64[ns]'):
+        unix_time //= 10**9
+    return unix_time
 
 
 def get_stype_proposal(db: Database) -> Dict[str, Dict[str, Any]]:

--- a/relbench/external/graph.py
+++ b/relbench/external/graph.py
@@ -20,9 +20,9 @@ from relbench.data.task import Task
 def to_unix_time(ser: pd.Series) -> Tensor:
     r"""Converts a :class:`pandas.Timestamp` series to UNIX timestamp
     (in seconds)."""
-    assert ser.dtype in [np.dtype('datetime64[s]'), np.dtype('datetime64[ns]')]
+    assert ser.dtype in [np.dtype("datetime64[s]"), np.dtype("datetime64[ns]")]
     unix_time = torch.from_numpy(ser.astype(int).values)
-    if ser.dtype == np.dtype('datetime64[ns]'):
+    if ser.dtype == np.dtype("datetime64[ns]"):
         unix_time //= 10**9
     return unix_time
 

--- a/relbench/utils.py
+++ b/relbench/utils.py
@@ -9,12 +9,6 @@ import requests
 from tqdm import tqdm
 
 
-def to_unix_time(column: pd.Series) -> pd.Series:
-    """convert a timestamp column to unix time"""
-    # return pd.to_datetime(column).astype('int64') // 10**9
-    return pd.to_datetime(column).astype("datetime64[s]")
-
-
 def unzip_processor(fname: Union[str, Path], action: str, pooch: pooch.Pooch) -> Path:
     zip_path = Path(fname)
     unzip_path = zip_path.parent / zip_path.stem


### PR DESCRIPTION
From pandas v2, the default time `dtype` becomes `[s]` not `[ns]`.