### PR TITLE
remove time leakage columns

### DIFF
--- a/relbench/datasets/stackex.py
+++ b/relbench/datasets/stackex.py
@@ -47,6 +47,7 @@ class StackExDataset(RelBenchDataset):
             columns=["Reputation", "Views", "UpVotes", "DownVotes", "LastAccessDate"],
             inplace=True,
         )
+
         posts.drop(
             columns=[
                 "ViewCount",
@@ -58,6 +59,9 @@ class StackExDataset(RelBenchDataset):
                 "LastEditDate",
                 "LastActivityDate",
                 "Score",
+                "LastEditorDisplayName",
+                "LastEditorUserId",
+                "AcceptedAnswerId"
             ],
             inplace=True,
         )
@@ -131,7 +135,6 @@ class StackExDataset(RelBenchDataset):
             df=pd.DataFrame(posts),
             fkey_col_to_pkey_table={
                 "OwnerUserId": "users",
-                "LastEditorUserId": "users",
                 "ParentId": "posts",  # notice the self-reference
             },
             pkey_col="Id",

--- a/relbench/datasets/stackex.py
+++ b/relbench/datasets/stackex.py
@@ -61,7 +61,7 @@ class StackExDataset(RelBenchDataset):
                 "Score",
                 "LastEditorDisplayName",
                 "LastEditorUserId",
-                "AcceptedAnswerId"
+                "AcceptedAnswerId",
             ],
             inplace=True,
         )


### PR DESCRIPTION
"LastEditorDisplayName"  "LastEditorUserId" "AcceptedAnswerId" these three columns have values that have temporal leakage. so we remove them