### PR TITLE
[Regression task improvement] Add clamping and increase aggregation time window

### DIFF
--- a/examples/baseline.py
+++ b/examples/baseline.py
@@ -53,7 +53,7 @@ def evaluate(train_table: Table, pred_table: Table, name: str) -> Dict[str, floa
         pred = np.random.rand(len(pred_table))
     elif name == "majority":
         past_target = train_table.df[task.target_col].astype(int)
-        majority_label = int(past_target.mode())
+        majority_label = int(past_target.mode().iloc[0])
         pred = torch.full((len(pred_table),), fill_value=majority_label)
     else:
         raise ValueError("Unknown eval name called {name}.")

--- a/examples/gnn.py
+++ b/examples/gnn.py
@@ -23,7 +23,6 @@ from relbench.data import RelBenchDataset
 from relbench.data.task import TaskType
 from relbench.datasets import get_dataset
 from relbench.external.graph import (
-    get_stype_proposal,
     get_train_table_input,
     make_pkey_fkey_graph,
 )
@@ -33,7 +32,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--dataset", type=str, default="rel-stackex")
 parser.add_argument("--task", type=str, default="rel-stackex-engage")
 parser.add_argument("--lr", type=float, default=0.01)
-parser.add_argument("--epochs", type=int, default=20)
+parser.add_argument("--epochs", type=int, default=10)
 parser.add_argument("--batch_size", type=int, default=512)
 parser.add_argument("--channels", type=int, default=128)
 parser.add_argument("--aggr", type=str, default="sum")
@@ -82,6 +81,7 @@ for split, table in [
         persistent_workers=args.num_workers > 0,
     )
 
+clamp_min, clamp_max = None, None
 if task.task_type == TaskType.BINARY_CLASSIFICATION:
     out_channels = 1
     loss_fn = BCEWithLogitsLoss()
@@ -92,6 +92,8 @@ elif task.task_type == TaskType.REGRESSION:
     loss_fn = L1Loss()
     tune_metric = "mae"
     higher_is_better = False
+    # Get the clamp value at inference time
+    clamp_min, clamp_max = np.percentile(task.train_table.df[task.target_col].to_numpy(), [2, 98])
 
 
 class Model(torch.nn.Module):
@@ -121,6 +123,7 @@ class Model(torch.nn.Module):
         self.head = MLP(
             args.channels,
             out_channels=out_channels,
+            norm="batch_norm",
             num_layers=1,
         )
 
@@ -147,7 +150,10 @@ class Model(torch.nn.Module):
             num_sampled_edges_dict,
         )
 
-        return self.head(x_dict[entity_table][: seed_time.size(0)])
+        out = self.head(x_dict[entity_table][: seed_time.size(0)])
+        if not self.training and task.task_type == TaskType.REGRESSION:
+            out = torch.clamp(out, clamp_min, clamp_max)
+        return out
 
 
 model = Model().to(device)

--- a/relbench/datasets/stackex.py
+++ b/relbench/datasets/stackex.py
@@ -10,6 +10,7 @@ from relbench.utils import unzip_processor
 
 class StackExDataset(RelBenchDataset):
     name = "rel-stackex"
+    # 2 years gap
     val_timestamp = pd.Timestamp("2019-01-01")
     test_timestamp = pd.Timestamp("2021-01-01")
     task_cls_list = [EngageTask, VotesTask, BadgesTask]

--- a/relbench/tasks/stackex.py
+++ b/relbench/tasks/stackex.py
@@ -120,7 +120,7 @@ class VotesTask(RelBenchTask):
                 LEFT JOIN votes v
                 ON p.id = v.PostId
                 and v.CreationDate > t.timestamp
-                and v.CreationDate <= t.timestamp + INTERVAL '{self.timedelta} days'
+                and v.CreationDate <= t.timestamp + INTERVAL '{self.timedelta}'
                 and v.votetypeid = 2
                 GROUP BY t.timestamp, p.id
             ;
@@ -137,7 +137,7 @@ class VotesTask(RelBenchTask):
 
 
 class BadgesTask(RelBenchTask):
-    r"""Predict if each user will receive in a new badge the next 2 years."""
+    r"""Predict if each user will receive in a new badge the next 1 year."""
     name = "rel-stackex-badges"
     task_type = TaskType.BINARY_CLASSIFICATION
     entity_col = "UserId"
@@ -164,7 +164,7 @@ class BadgesTask(RelBenchTask):
             LEFT JOIN badges b
                 ON u.Id = b.UserID
                 AND b.Date > t.timestamp
-                AND b.Date <= t.timestamp + INTERVAL 2 years
+                AND b.Date <= t.timestamp + INTERVAL {self.timedelta}
             GROUP BY t.timestamp, u.Id
             """
         ).df()


### PR DESCRIPTION
- Add clamping logic at inference time
- Increase the aggregation window of `rel-stackex-votes` from 1 year to 2 years.