### PR TITLE
Improve unzip processor step when action is fetch

### DIFF
--- a/relbench/utils.py
+++ b/relbench/utils.py
@@ -1,6 +1,8 @@
+import os
 import shutil
 from pathlib import Path
 from typing import Union
+from zipfile import ZipFile
 
 import pooch
 
@@ -8,7 +10,17 @@ import pooch
 def unzip_processor(fname: Union[str, Path], action: str, pooch: pooch.Pooch) -> Path:
     zip_path = Path(fname)
     unzip_path = zip_path.parent / zip_path.stem
-    shutil.unpack_archive(zip_path, unzip_path)
+    if action != 'fetch':
+        shutil.unpack_archive(zip_path, unzip_path)
+    else:  # fetch
+        try: # sanity check if all files are fully extracted comparing size
+            for f in ZipFile(zip_path).infolist():
+                if not f.is_dir():
+                    fsize = os.path.getsize(os.path.join(unzip_path, f.filename))
+                    assert f.file_size == fsize
+        except Exception:  # otherwise do full unpack
+            shutil.unpack_archive(zip_path, unzip_path)
+
     return unzip_path
 
 

--- a/relbench/utils.py
+++ b/relbench/utils.py
@@ -10,10 +10,10 @@ import pooch
 def unzip_processor(fname: Union[str, Path], action: str, pooch: pooch.Pooch) -> Path:
     zip_path = Path(fname)
     unzip_path = zip_path.parent / zip_path.stem
-    if action != 'fetch':
+    if action != "fetch":
         shutil.unpack_archive(zip_path, unzip_path)
     else:  # fetch
-        try: # sanity check if all files are fully extracted comparing size
+        try:  # sanity check if all files are fully extracted comparing size
             for f in ZipFile(zip_path).infolist():
                 if not f.is_dir():
                     fsize = os.path.getsize(os.path.join(unzip_path, f.filename))


### PR DESCRIPTION
When unzip_processor is used for pooch library there is unnecessary `unpack_archive` step for mode/action == 'fetch'. In this mode all files should already be unpacked and skipping this step improves performance of the subsequent `python gnn_node.py` runs (after the initial one that prepares the data) by **1.6x**  .

making Database object from raw files...
done in **29.23** seconds.
reindexing pkeys and fkeys...
done in 1.33 seconds.

making Database object from raw files...
done in **17.97** seconds.
reindexing pkeys and fkeys...
done in 1.33 seconds.