### PR TITLE
Improve `StackEx` dataset creation from raw files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies=[
 	"requests",
 	"tqdm",
 	"scikit-learn",
-	"typing-extensions"
+	"typing-extensions",
+	"fastparquet"
 ]
 
 [project.optional-dependencies]

--- a/relbench/datasets/stackex.py
+++ b/relbench/datasets/stackex.py
@@ -46,17 +46,42 @@ class StackExDataset(RelBenchDataset):
             processor=unzip_and_convert_csv_to_parquet_processor,
         )
         path = os.path.join(path, "raw")
-        users_cols = ('Id', 'AccountId', 'DisplayName', 'Location',
-                      'ProfileImageUrl', 'WebsiteUrl', 'AboutMe',
-                      'CreationDate')
-        comments_cols = ('Id', 'PostId', 'UserId', 'ContentLicense',
-                         'UserDisplayName', 'Text', 'CreationDate')
-        posts_cols = ('Id', 'OwnerUserId', 'PostTypeId', 'AcceptedAnswerId',
-                      'ParentId', 'OwnerDisplayName', 'Title', 'Tags',
-                      'ContentLicense', 'Body', 'CreationDate')
-        votes_cols = ('Id', 'UserId', 'PostId', 'VoteTypeId', 'CreationDate')
+        users_cols = (
+            "Id",
+            "AccountId",
+            "DisplayName",
+            "Location",
+            "ProfileImageUrl",
+            "WebsiteUrl",
+            "AboutMe",
+            "CreationDate",
+        )
+        comments_cols = (
+            "Id",
+            "PostId",
+            "UserId",
+            "ContentLicense",
+            "UserDisplayName",
+            "Text",
+            "CreationDate",
+        )
+        posts_cols = (
+            "Id",
+            "OwnerUserId",
+            "PostTypeId",
+            "AcceptedAnswerId",
+            "ParentId",
+            "OwnerDisplayName",
+            "Title",
+            "Tags",
+            "ContentLicense",
+            "Body",
+            "CreationDate",
+        )
+        votes_cols = ("Id", "UserId", "PostId", "VoteTypeId", "CreationDate")
         read_parquet = lambda fname, col_names: pd.read_parquet(
-            os.path.join(path, fname), columns=col_names, engine='fastparquet')
+            os.path.join(path, fname), columns=col_names, engine="fastparquet"
+        )
 
         users = read_parquet("Users.parquet", users_cols)
         comments = read_parquet("Comments.parquet", comments_cols)

--- a/relbench/utils.py
+++ b/relbench/utils.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Union
 from zipfile import ZipFile
 
+import pandas as pd
 import pooch
 
 
@@ -20,6 +21,22 @@ def unzip_processor(fname: Union[str, Path], action: str, pooch: pooch.Pooch) ->
                     assert f.file_size == fsize
         except Exception:  # otherwise do full unpack
             shutil.unpack_archive(zip_path, unzip_path)
+
+    return unzip_path
+
+
+def unzip_and_convert_csv_to_parquet_processor(fname: Union[str,
+                                                            Path], action: str,
+                                               pooch: pooch.Pooch) -> Path:
+    unzip_path = unzip_processor(fname, action, pooch)
+
+    # Convert csv to parquet
+    for csv_file in unzip_path.glob('**/*.csv'):
+        parquet_file = csv_file.with_suffix('.parquet')
+        if not parquet_file.exists(
+        ):  # Only convert if parquet file does not exist
+            df = pd.read_csv(csv_file)
+            df.to_parquet(parquet_file)
 
     return unzip_path
 

--- a/relbench/utils.py
+++ b/relbench/utils.py
@@ -25,16 +25,15 @@ def unzip_processor(fname: Union[str, Path], action: str, pooch: pooch.Pooch) ->
     return unzip_path
 
 
-def unzip_and_convert_csv_to_parquet_processor(fname: Union[str,
-                                                            Path], action: str,
-                                               pooch: pooch.Pooch) -> Path:
+def unzip_and_convert_csv_to_parquet_processor(
+    fname: Union[str, Path], action: str, pooch: pooch.Pooch
+) -> Path:
     unzip_path = unzip_processor(fname, action, pooch)
 
     # Convert csv to parquet
-    for csv_file in unzip_path.glob('**/*.csv'):
-        parquet_file = csv_file.with_suffix('.parquet')
-        if not parquet_file.exists(
-        ):  # Only convert if parquet file does not exist
+    for csv_file in unzip_path.glob("**/*.csv"):
+        parquet_file = csv_file.with_suffix(".parquet")
+        if not parquet_file.exists():  # Only convert if parquet file does not exist
             df = pd.read_csv(csv_file)
             df.to_parquet(parquet_file)
 


### PR DESCRIPTION
`StackEx` creation from raw files can be significantly improved by converting `.csv` files to `.parquet` files. The latter format allows us to use `fastparquet` engine that employs multiple threads. Additionally, instead of loading all columns and then dropping some of them, we can load only the necessary columns. Overall, **it results in a 3.5x faster load time**.

I tried different engines/frameworks to load `.csv` files (such as modin, dask, pyarrow), but they all struggled when `.csv` files contained corrupted rows, such as single value without separators. It is generally advisable, to prefer the `.parquet` format.