### PR TITLE
Added db cache to stackex dataset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies=[
 	"requests",
 	"tqdm",
 	"scikit-learn",
-	"typing-extensions"
+	"typing-extensions",
+	"fastparquet"
 ]
 
 [project.optional-dependencies]

--- a/relbench/data/table.py
+++ b/relbench/data/table.py
@@ -81,7 +81,7 @@ class Table:
         assert str(path).endswith(".parquet")
 
         # Read the Parquet file using pyarrow
-        df = pd.read_parquet(path, engine='fastparquet')
+        df = pd.read_parquet(path, engine="fastparquet")
         # Extract metadata
         metadata_bytes = pa.parquet.read_metadata(path).metadata
         metadata = {

--- a/relbench/data/table.py
+++ b/relbench/data/table.py
@@ -81,11 +81,9 @@ class Table:
         assert str(path).endswith(".parquet")
 
         # Read the Parquet file using pyarrow
-        table = pa.parquet.read_table(path)
-        df = table.to_pandas()
-
+        df = pd.read_parquet(path, engine='fastparquet')
         # Extract metadata
-        metadata_bytes = table.schema.metadata
+        metadata_bytes = pa.parquet.read_metadata(path).metadata
         metadata = {
             key.decode("utf-8"): json.loads(value.decode("utf-8"))
             for key, value in metadata_bytes.items()

--- a/relbench/datasets/stackex.py
+++ b/relbench/datasets/stackex.py
@@ -38,10 +38,12 @@ class StackExDataset(RelBenchDataset):
         *,
         process: bool = False,
         use_db_cache: bool = True,
-        keep_raw_csv: bool = False
+        keep_raw_csv: bool = False,
     ):
         self.name = f"{self.name}"
-        self.local_db_cache_path = os.path.join(pooch.os_cache(self.name), self.db_dir, 'raw')
+        self.local_db_cache_path = os.path.join(
+            pooch.os_cache(self.name), self.db_dir, "raw"
+        )
         self.inf_file_path = os.path.join(self.local_db_cache_path, "db.inf")
         self.use_db_cache = use_db_cache
         self.keep_raw_csv = keep_raw_csv  # don't delete imtermediate csv files
@@ -176,13 +178,13 @@ class StackExDataset(RelBenchDataset):
                 return f.readline().strip() == self.inf_file_line
         return False
 
-    def clear_local_db(self, db_path:str):
+    def clear_local_db(self, db_path: str):
         print("Removing db cache files")
         for table_path in Path(db_path).glob("*.parquet"):
             os.remove(str(table_path))
         os.remove(os.path.join(db_path, "db.inf"))
 
-    def clear_csv(self, csv_path:str):
+    def clear_csv(self, csv_path: str):
         print("Removing raw csv files")
         for table_path in Path(csv_path).glob("*.csv"):
             os.remove(str(table_path))
@@ -197,18 +199,17 @@ class StackExDataset(RelBenchDataset):
             db, csv_path = self.create_db()
             if self.use_db_cache:
                 if not self.keep_raw_csv:
-                # raw csv files are not needed when db_cache is used
+                    # raw csv files are not needed when db_cache is used
                     self.clear_csv(csv_path)
 
                 print(f"saving Database object to {db_path}")
                 db.save(db_path)
 
                 # add db.inf file to the db_path with url and known_hash
-                with open(self.inf_file_path, 'w') as f:
+                with open(self.inf_file_path, "w") as f:
                     f.write(f"{self.inf_file_line}\n")
             elif self.check_db():
                 # local cache database files are not needed in this case
                 self.clear_local_db(db_path)
 
         return db
-

--- a/relbench/datasets/stackex.py
+++ b/relbench/datasets/stackex.py
@@ -18,6 +18,9 @@ from relbench.utils import unzip_processor
 
 class StackExDataset(RelBenchDataset):
     name = "rel-stackex"
+    url = "https://relbench.stanford.edu/data/relbench-forum-raw.zip"
+    known_hash = "ad3bf96f35146d50ef48fa198921685936c49b95c6b67a8a47de53e90036745f"
+    inf_file_line = f"{url} = {known_hash}"
     # 2 years gap
     val_timestamp = pd.Timestamp("2019-01-01")
     test_timestamp = pd.Timestamp("2021-01-01")
@@ -39,23 +42,17 @@ class StackExDataset(RelBenchDataset):
     ):
         self.name = f"{self.name}"
         self.local_db_cache_path = os.path.join(pooch.os_cache(self.name), self.db_dir, 'raw')
+        self.inf_file_path = os.path.join(self.local_db_cache_path, "db.inf")
         self.use_db_cache = use_db_cache
         self.keep_raw_csv = keep_raw_csv  # don't delete imtermediate csv files
 
         super().__init__(process=process)
 
-    def check_db(self) -> bool:
-        r"Check if local database is OK"
-        if os.path.isdir(self.local_db_cache_path):
-            return any(os.scandir(self.local_db_cache_path))  # check if empty
-        return False
-
     def create_db(self) -> Tuple[Database, str]:
         r"""Process the raw files into a database."""
-        url = "https://relbench.stanford.edu/data/relbench-forum-raw.zip"
         path = pooch.retrieve(
-            url,
-            known_hash="ad3bf96f35146d50ef48fa198921685936c49b95c6b67a8a47de53e90036745f",
+            self.url,
+            known_hash=self.known_hash,
             progressbar=True,
             processor=unzip_processor,
         )
@@ -171,25 +168,47 @@ class StackExDataset(RelBenchDataset):
 
         return Database(tables), path
 
+    def check_db(self) -> bool:
+        r"Check if local database is OK"
+        if Path(self.inf_file_path).exists():
+            with open(self.inf_file_path) as f:
+                # check if inf_file contains matching url and hash of zip file
+                return f.readline().strip() == self.inf_file_line
+        return False
+
+    def clear_local_db(self, db_path:str):
+        print("Removing db cache files")
+        for table_path in Path(db_path).glob("*.parquet"):
+            os.remove(str(table_path))
+        os.remove(os.path.join(db_path, "db.inf"))
+
+    def clear_csv(self, csv_path:str):
+        print("Removing raw csv files")
+        for table_path in Path(csv_path).glob("*.csv"):
+            os.remove(str(table_path))
+
     def make_db(self) -> Database:
         r"""Process the raw files into a database or load cached database."""
+        db_path = self.local_db_cache_path
         if self.use_db_cache and self.check_db():
-            print(f"Loading db from {self.local_db_cache_path}")
-            db = Database.load(self.local_db_cache_path)
+            print(f"Loading db from {db_path}")
+            db = Database.load(db_path)
         else:
-            db, path = self.create_db()
+            db, csv_path = self.create_db()
             if self.use_db_cache:
                 if not self.keep_raw_csv:
-                    # raw csv files are not needed when db_cache is used
-                    print("Removing raw csv files")
-                    for table_path in Path(path).glob("*.csv"):
-                        os.remove(table_path)
+                # raw csv files are not needed when db_cache is used
+                    self.clear_csv(csv_path)
 
-                db.save(self.local_db_cache_path)
+                print(f"saving Database object to {db_path}")
+                db.save(db_path)
+
+                # add db.inf file to the db_path with url and known_hash
+                with open(self.inf_file_path, 'w') as f:
+                    f.write(f"{self.inf_file_line}\n")
             elif self.check_db():
                 # local cache database files are not needed in this case
-                print("Removing db cache files")
-                for table_path in Path(self.local_db_cache_path).glob("*.parquet"):
-                    os.remove(table_path)
+                self.clear_local_db(db_path)
 
         return db
+


### PR DESCRIPTION
This PR adds local database cache to `StackExDataset` when `process==True` to improve performance.
Usage:
 `dataset: RelBenchDataset = get_dataset(name=args.dataset, process=True, use_db_cache=False)`

- when use_db_cache==True (default) it saves csv data into local Database cache. Next time database is loaded from cache. 
- when use_db_cache==False, data is read from csv files

In order to keep disk usage low when db_cache is used, intermediate csv files are removed, in the opposite case database cache files are removed.

After the changes performance of the subsequent `python gnn_node.py` runs (after the initial one) improves by **4.8x** with `fastparquet` (default here) and **1.5x** with the default one.
 
making Database object from raw files...
done in **17.94** seconds.
reindexing pkeys and fkeys...
done in 1.34 seconds.

making Database object from raw files...
Loading db from /home/artur/.cache/rel-stackex/db/raw
done in **3.63** seconds.
reindexing pkeys and fkeys...
done in 1.35 seconds.