### PR TITLE
Fix parsing error in `datasets/math_stackex.py`

### DIFF
--- a/relbench/datasets/math_stackex.py
+++ b/relbench/datasets/math_stackex.py
@@ -53,7 +53,9 @@ class MathStackExDataset(RelBenchDataset):
         path = os.path.join(path, "math-stackex-temp")
         print("Loading data from:", path)
         users = pd.read_csv(os.path.join(path, "Users.csv"))
-        comments = pd.read_csv(os.path.join(path, "Comments.csv"), low_memory=False)
+        comments = pd.read_csv(
+            os.path.join(path, "Comments.csv"), low_memory=False, lineterminator="\n"
+        )
         posts = pd.read_csv(os.path.join(path, "Posts.csv"))
 
         votes = pd.read_csv(os.path.join(path, "Votes.csv"))


### PR DESCRIPTION
Adding `low_memory=False` to the `read_csv` call in line 56 causes the following error:

`pandas.errors.ParserError: Error tokenizing data. C error: Buffer overflow caught - possible malformed input file.`

Specifying `lineterminator="\n"` solves the issue.