### PR TITLE
[Bug] Fix a potential seed time bug for link prediction script

### DIFF
--- a/relbench/data/task_link.py
+++ b/relbench/data/task_link.py
@@ -116,7 +116,7 @@ class LinkTask(BaseTask):
 
     @property
     def test_seed_time(self) -> int:
-        return to_unix_time(pd.Series([self.dataset.val_timestamp]))[0]
+        return to_unix_time(pd.Series([self.dataset.test_timestamp]))[0]
 
 
 class RelBenchLinkTask(LinkTask):


### PR DESCRIPTION
Now the validation and test sets have the same seed time, which is used for the neighbor loader here https://github.com/snap-stanford/relbench/blob/a7c185067569672ad169a5eda8389e156930723b/examples/gnn_link.py#L91 This seems to be a bug.