### PR TITLE
obtain the num_src_nodes and num_dst_nodes from full_db instead

### DIFF
--- a/relbench/data/task_base.py
+++ b/relbench/data/task_base.py
@@ -145,7 +145,7 @@ class BaseTask:
             self._cached_table_dict["full_test"] = full_table
         else:
             full_table = self._cached_table_dict["full_test"]
-        self._full_test_table = self.filter_dangling_entities(full_table)
+        self._full_test_table = self.filter_dangling_entities(full_table, is_test=True)
 
         return self._mask_input_cols(self._full_test_table)
 

--- a/relbench/data/task_link.py
+++ b/relbench/data/task_link.py
@@ -52,6 +52,9 @@ class LinkTask(BaseTask):
         return f"{self.__class__.__name__}(dataset={self.dataset})"
 
     def filter_dangling_entities(self, table: Table, is_test: bool = False) -> Table:
+        # We filter out test data in self.db to avoid information leakage.
+        # Here when we filter dangling entities for test set, we need to
+        # read the num_src_nodes and num_dst_nodes from unfiltered db.
         if not is_test:
             num_src_nodes = self.num_src_nodes
             num_dst_nodes = self.num_dst_nodes

--- a/relbench/data/task_link.py
+++ b/relbench/data/task_link.py
@@ -104,11 +104,11 @@ class LinkTask(BaseTask):
 
     @property
     def num_src_nodes(self) -> int:
-        return len(self.dataset.db.table_dict[self.src_entity_table])
+        return len(self.dataset._full_db.table_dict[self.src_entity_table])
 
     @property
     def num_dst_nodes(self) -> int:
-        return len(self.dataset.db.table_dict[self.dst_entity_table])
+        return len(self.dataset._full_db.table_dict[self.dst_entity_table])
 
     @property
     def val_seed_time(self) -> int:

--- a/relbench/data/task_node.py
+++ b/relbench/data/task_node.py
@@ -38,8 +38,11 @@ class NodeTask(BaseTask):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(dataset={self.dataset})"
 
-    def filter_dangling_entities(self, table: Table) -> Table:
-        num_entities = len(self.dataset.db.table_dict[self.entity_table])
+    def filter_dangling_entities(self, table: Table, is_test: bool = False) -> Table:
+        if not is_test:
+            num_entities = len(self.dataset.db.table_dict[self.entity_table])
+        else:
+            num_entities = len(self.dataset._full_db.table_dict[self.entity_table])
         filter_mask = table.df[self.entity_col] >= num_entities
 
         if filter_mask.any():


### PR DESCRIPTION
This is a quite obvious bug. Previously, we are filtering out all the src and dst nodes that appear after the test_timestamp. So this would result into an empty test table