### PR TITLE
Add sanity check for `ID-GNN`

### DIFF
--- a/examples/idgnn_link.py
+++ b/examples/idgnn_link.py
@@ -144,10 +144,12 @@ def train() -> float:
             break
 
     if count_accum == 0:
-        raise ValueError(f"Did not sample a single '{task.dst_entity_table}' "
-                         f"node in any mini-batch. Try to increase the number "
-                         f"of layers/hops and re-try. If you run into memory "
-                         f"issues with deeper nets, decrease the batch size.")
+        raise ValueError(
+            f"Did not sample a single '{task.dst_entity_table}' "
+            f"node in any mini-batch. Try to increase the number "
+            f"of layers/hops and re-try. If you run into memory "
+            f"issues with deeper nets, decrease the batch size."
+        )
 
     return loss_accum / count_accum
 

--- a/examples/idgnn_link.py
+++ b/examples/idgnn_link.py
@@ -143,6 +143,12 @@ def train() -> float:
         if steps > args.max_steps_per_epoch:
             break
 
+    if count_accum == 0:
+        raise ValueError(f"Did not sample a single '{task.dst_entity_table}' "
+                         f"node in any mini-batch. Try to increase the number "
+                         f"of layers/hops and re-try. If you run into memory "
+                         f"issues with deeper nets, decrease the batch size.")
+
     return loss_accum / count_accum
 
 


### PR DESCRIPTION
On trials, `IDGNN` needs four hops to sample sponsors.