### PR TITLE
[Avito] Update Avito data with 1 link pred task, 1 regression task and 2 binary classification task

### DIFF
--- a/relbench/datasets/avito.py
+++ b/relbench/datasets/avito.py
@@ -6,7 +6,12 @@ import pandas as pd
 import pooch
 
 from relbench.data import Database, RelBenchDataset, Table
-from relbench.tasks.avito import UserAdClickTask, UserClicksTask
+from relbench.tasks.avito import (
+    AdsClicksTask,
+    UserAdVisitTask,
+    UserClicksTask,
+    UserVisitsTask,
+)
 from relbench.utils import clean_datetime, unzip_processor
 
 
@@ -16,10 +21,10 @@ class AvitoDataset(RelBenchDataset):
 
     # search stream ranges from 2015-04-25 to 2015-05-20
     train_start_timestamp = pd.Timestamp("2015-04-25")
-    val_timestamp = pd.Timestamp("2015-05-09")
+    val_timestamp = pd.Timestamp("2015-05-08")
     test_timestamp = pd.Timestamp("2015-05-14")
     max_eval_time_frames = 1
-    task_cls_list = [UserClicksTask, UserAdClickTask]
+    task_cls_list = [AdsClicksTask, UserVisitsTask, UserAdVisitTask, UserClicksTask]
 
     def __init__(
         self,

--- a/relbench/tasks/avito.py
+++ b/relbench/tasks/avito.py
@@ -4,6 +4,9 @@ import pandas as pd
 from relbench.data import Database, RelBenchLinkTask, RelBenchNodeTask, Table
 from relbench.data.task_base import TaskType
 from relbench.metrics import (
+    accuracy,
+    average_precision,
+    f1,
     link_prediction_map,
     link_prediction_precision,
     link_prediction_recall,
@@ -14,21 +17,125 @@ from relbench.metrics import (
 )
 
 
-class UserClicksTask(RelBenchNodeTask):
-    r"""Predict the total number of ads each customer will click in the
-    next 4 days
+class AdsClicksTask(RelBenchNodeTask):
+    r"""Assuming the ad will be clicked in the next 4 days, predict the CTR
+    for each ad.
     """
 
-    name = "user-clicks"
+    name = "ads-clicks"
     task_type = TaskType.REGRESSION
-    entity_table = "UserInfo"
-    entity_col = "UserID"
+    entity_table = "AdsInfo"
+    entity_col = "AdID"
     time_col = "timestamp"
     target_col = "num_click"
     timedelta = pd.Timedelta(days=4)
     metrics = [r2, mae, rmse]
 
     def make_table(self, db: Database, timestamps: "pd.Series[pd.Timestamp]") -> Table:
+        ads_info = db.table_dict["AdsInfo"].df
+        search_stream = db.table_dict["SearchStream"].df
+        timestamp_df = pd.DataFrame({"timestamp": timestamps})
+        df = duckdb.sql(
+            f"""
+            SELECT
+                search_ads.AdID,
+                t.timestamp,
+                COALESCE(SUM(search_ads.isClick), 0) / COALESCE(COUNT(search_ads.SearchID), 1) AS num_click
+            FROM
+                timestamp_df t
+            LEFT JOIN (
+                ads_info
+                    LEFT JOIN
+                search_stream
+                    ON
+                ads_info.AdID == search_stream.AdID
+            ) search_ads
+            ON
+                search_ads.SearchDate > t.timestamp AND
+                search_ads.SearchDate <= t.timestamp + INTERVAL '{self.timedelta} days'
+            GROUP BY
+                t.timestamp,
+                search_ads.AdID
+            HAVING
+                SUM(search_ads.isClick) > 0
+            """
+        ).df()
+
+        return Table(
+            df=df,
+            fkey_col_to_pkey_table={"AdID": "entity_table"},
+            pkey_col=None,
+            time_col="timestamp",
+        )
+
+
+class UserVisitsTask(RelBenchNodeTask):
+    r"""Predict whether each customer will visit more than one ad in the next
+    5 dyas.
+    """
+
+    name = "user-visits"
+    task_type = TaskType.BINARY_CLASSIFICATION
+    entity_table = "UserInfo"
+    entity_col = "UserID"
+    time_col = "timestamp"
+    target_col = "num_click"
+    timedelta = pd.Timedelta(days=4)
+    metrics = [average_precision, accuracy, f1, roc_auc]
+
+    def make_table(self, db: Database, timestamps: "pd.Series[pd.Timestamp]") -> Table:
+        user_info = db.table_dict["UserInfo"].df
+        visits_stream = db.table_dict["VisitStream"].df
+        timestamp_df = pd.DataFrame({"timestamp": timestamps})
+        df = duckdb.sql(
+            f"""
+            SELECT
+                visit_ads.UserID,
+                t.timestamp,
+                COALESCE(COUNT(DISTINCT visit_ads.AdID), 0) > 1 AS num_click
+            FROM
+                timestamp_df t
+            LEFT JOIN
+            (
+                    user_info
+                LEFT JOIN
+                    visits_stream
+                ON
+                    user_info.UserID == visits_stream.UserID
+            ) visit_ads
+            ON
+                visit_ads.ViewDate > t.timestamp AND
+                visit_ads.ViewDate <= t.timestamp + INTERVAL '{self.timedelta} days'
+            GROUP BY
+                t.timestamp,
+                visit_ads.UserID
+            """
+        ).df()
+
+        return Table(
+            df=df,
+            fkey_col_to_pkey_table={"UserID": "entity_table"},
+            pkey_col=None,
+            time_col="timestamp",
+        )
+
+
+class UserClicksTask(RelBenchNodeTask):
+    r"""Predict the each customer will click on more than one ads in the
+    next 4 days
+    """
+
+    name = "user-clicks"
+    task_type = TaskType.BINARY_CLASSIFICATION
+    entity_table = "UserInfo"
+    entity_col = "UserID"
+    time_col = "timestamp"
+    target_col = "num_click"
+    timedelta = pd.Timedelta(days=4)
+    metrics = [average_precision, accuracy, f1, roc_auc]
+
+    def make_table(self, db: Database, timestamps: "pd.Series[pd.Timestamp]") -> Table:
+        user_info = db.table_dict["UserInfo"].df
         search_info = db.table_dict["SearchInfo"].df
         search_stream = db.table_dict["SearchStream"].df
         timestamp_df = pd.DataFrame({"timestamp": timestamps})
@@ -37,16 +144,22 @@ class UserClicksTask(RelBenchNodeTask):
             SELECT
                 search_ads.UserID,
                 t.timestamp,
-                COUNT(search_ads.AdID) AS num_click,
+                COALESCE(COUNT(search_ads.AdID), 0) > 1 AS num_click
             FROM
                 timestamp_df t
             LEFT JOIN
             (
+                (
+                    user_info
+                        LEFT JOIN
                     search_info
-                INNER JOIN
+                        ON
+                    user_info.UserID == search_info.UserID
+                ) user_search_info
+                LEFT JOIN
                     search_stream
                 ON
-                    search_info.SearchID == search_stream.SearchID AND
+                    user_search_info.SearchID == search_stream.SearchID AND
                     search_stream.IsClick == 1.0
             ) search_ads
             ON
@@ -66,10 +179,10 @@ class UserClicksTask(RelBenchNodeTask):
         )
 
 
-class UserAdClickTask(RelBenchLinkTask):
-    r"""Predict the list of ads user will click in the next 4 days"""
+class UserAdVisitTask(RelBenchLinkTask):
+    r"""Predict the list of ads user will visit in the next 4 days"""
 
-    name = "user-ad-click"
+    name = "user-ad-visit"
     task_type = TaskType.LINK_PREDICTION
     src_entity_table = "UserInfo"
     src_entity_col = "UserID"
@@ -83,33 +196,32 @@ class UserAdClickTask(RelBenchLinkTask):
     eval_k = 12
 
     def make_table(self, db: Database, timestamps: "pd.Series[pd.Timestamp]") -> Table:
-        search_info = db.table_dict["SearchInfo"].df
-        search_stream = db.table_dict["SearchStream"].df
+        user_info = db.table_dict["UserInfo"].df
+        visits_stream = db.table_dict["VisitStream"].df
         timestamp_df = pd.DataFrame({"timestamp": timestamps})
 
         df = duckdb.sql(
             f"""
             SELECT
-                search_ads.UserID,
+                visit_ads.UserID,
                 t.timestamp,
-                LIST(search_ads.AdID) AS AdID,
+                LIST(DISTINCT visit_ads.AdID) AS AdID,
             FROM
                 timestamp_df t
             LEFT JOIN
             (
-                    search_info
-                INNER JOIN
-                    search_stream
+                    user_info
+                LEFT JOIN
+                    visits_stream
                 ON
-                    search_info.SearchID == search_stream.SearchID AND
-                    search_stream.IsClick == 1.0
-            ) search_ads
+                    user_info.UserID == visits_stream.UserID
+            ) visit_ads
             ON
-                search_ads.SearchDate > t.timestamp AND
-                search_ads.SearchDate <= t.timestamp + INTERVAL '{self.timedelta} days'
+                visit_ads.ViewDate > t.timestamp AND
+                visit_ads.ViewDate <= t.timestamp + INTERVAL '{self.timedelta} days'
             GROUP BY
                 t.timestamp,
-                search_ads.UserID
+                visit_ads.UserID
             """
         ).df()
         return Table(

--- a/relbench/tasks/avito.py
+++ b/relbench/tasks/avito.py
@@ -18,8 +18,8 @@ from relbench.metrics import (
 
 
 class AdsClicksTask(RelBenchNodeTask):
-    r"""Assuming the ad will be clicked in the next 4 days, predict the CTR
-    for each ad.
+    r"""Assuming the ad will be clicked in the next 4 days, predict the
+    Click-Through-Rate (CTR) for each ad.
     """
 
     name = "ads-clicks"
@@ -121,8 +121,8 @@ class UserVisitsTask(RelBenchNodeTask):
 
 
 class UserClicksTask(RelBenchNodeTask):
-    r"""Predict the each customer will click on more than one ads in the
-    next 4 days
+    r"""Predict whether the each customer will click on more than one ads in
+    the next 4 days
     """
 
     name = "user-clicks"
@@ -180,7 +180,7 @@ class UserClicksTask(RelBenchNodeTask):
 
 
 class UserAdVisitTask(RelBenchLinkTask):
-    r"""Predict the list of ads user will visit in the next 4 days"""
+    r"""Predict the distinct list of ads a user will visit in the next 4 days"""
 
     name = "user-ad-visit"
     task_type = TaskType.LINK_PREDICTION

--- a/relbench/tasks/avito.py
+++ b/relbench/tasks/avito.py
@@ -13,6 +13,7 @@ from relbench.metrics import (
     mae,
     r2,
     rmse,
+    roc_auc,
 )
 
 

--- a/relbench/tasks/avito.py
+++ b/relbench/tasks/avito.py
@@ -71,7 +71,7 @@ class AdsClicksTask(RelBenchNodeTask):
 
 class UserVisitsTask(RelBenchNodeTask):
     r"""Predict whether each customer will visit more than one ad in the next
-    5 dyas.
+    4 days.
     """
 
     name = "user-visits"


### PR DESCRIPTION
Follow up of https://github.com/snap-stanford/relbench/pull/171.

Summary:
1. Downsample the avito dataset to 100k in target table from 500k for faster iteration.
2. Propose a link prediction task to: Predict the list of ads user will visit in the next 4 days.
3. Propose a regression task to: Assuming the ad will be clicked in the next 4 days, predict the CTR for each ad.
4. Propose a binary classification task to: Predict whether each customer will visit more than one ad in the next 4 days.
5. Propose a binary classification task to: Predict the each customer will click on more than one ads in the next 4 day.

Benchmarking Result:
<img width="1391" alt="Screenshot 2024-06-13 at 1 51 50 PM" src="https://github.com/snap-stanford/relbench/assets/24365690/171505d6-0fcc-4e14-8ad1-5db289a1c38a">

<img width="621" alt="Screenshot 2024-06-13 at 1 23 20 PM" src="https://github.com/snap-stanford/relbench/assets/24365690/02745f1f-2c7f-45cf-80b3-e6a23b310761">

<img width="1484" alt="Screenshot 2024-06-13 at 1 23 45 PM" src="https://github.com/snap-stanford/relbench/assets/24365690/f6e3a5aa-3f89-4cf4-9fac-73d3fb4262d1">

<img width="640" alt="Screenshot 2024-06-13 at 11 12 32 PM" src="https://github.com/snap-stanford/relbench/assets/24365690/83668ed0-6c8a-460c-aa45-064ad788eb9b">

