### PR TITLE
Add pyarrow.json import

### DIFF
--- a/relbench/datasets/amazon.py
+++ b/relbench/datasets/amazon.py
@@ -3,6 +3,7 @@ import time
 import pandas as pd
 import pooch
 import pyarrow as pa
+import pyarrow.json
 
 from relbench.data import Database, Dataset, Table
 


### PR DESCRIPTION
pyarrow.json needs explicit import otherwise:
```
Traceback (most recent call last):
  File "/workspace/relbench/examples/gnn_link.py", line 65, in <module>
    dataset.get_db(),
  File "/usr/local/lib/python3.10/dist-packages/relbench/data/dataset.py", line 69, in get_db
    db = self.make_db()
  File "/usr/local/lib/python3.10/dist-packages/relbench/datasets/amazon.py", line 50, in make_db
    ptable = pa.json.read_json(
  File "/usr/local/lib/python3.10/dist-packages/pyarrow/__init__.py", line 317, in __getattr__
    raise AttributeError(
AttributeError: module 'pyarrow' has no attribute 'json'
```