### PR TITLE
SentenceTransformer encode with torch

### DIFF
--- a/examples/text_embedder.py
+++ b/examples/text_embedder.py
@@ -15,4 +15,4 @@ class GloveTextEmbedding:
         )
 
     def __call__(self, sentences: List[str]) -> Tensor:
-        return torch.from_numpy(self.model.encode(sentences))
+        return self.model.encode(sentences, convert_to_tensor=True)


### PR DESCRIPTION
10-20% faster processing than numpy (default encoding)