### PR TITLE
[FutureWarning] Resolving warnings caused by deprecated parameter `squared`.

### DIFF
--- a/relbench/metrics.py
+++ b/relbench/metrics.py
@@ -77,7 +77,7 @@ def mse(true: NDArray[np.float64], pred: NDArray[np.float64]) -> float:
 
 
 def rmse(true: NDArray[np.float64], pred: NDArray[np.float64]) -> float:
-    return skm.mean_squared_error(true, pred, squared=False)
+    return skm.root_mean_squared_error(true, pred)
 
 
 def r2(true: NDArray[np.float64], pred: NDArray[np.float64]) -> float:


### PR DESCRIPTION
This PR provides a fix for the following warning:
```
/usr/local/lib/python3.12/dist-packages/sklearn/metrics/_regression.py:493: FutureWarning: 'squared' is deprecated in version 1.4 and will be removed in 1.6. To calculate the root mean squared error, use the function'root_mean_squared_error'.
  warnings.warn(
```