### PR TITLE
Remove Extra LEFT JOIN In F1 Task SQLs

### DIFF
--- a/relbench/tasks/f1.py
+++ b/relbench/tasks/f1.py
@@ -29,7 +29,7 @@ class DriverPositionTask(EntityTask):
             f"""
                 SELECT
                     t.timestamp as date,
-                    dri.driverId as driverId,
+                    re.driverId as driverId,
                     mean(re.positionOrder) as position,
                 FROM
                     timestamp_df t
@@ -38,17 +38,13 @@ class DriverPositionTask(EntityTask):
                 ON
                     re.date <= t.timestamp + INTERVAL '{self.timedelta}'
                     and re.date  > t.timestamp
-                LEFT JOIN
-                    drivers dri
-                ON
-                    re.driverId = dri.driverId
                 WHERE
-                    dri.driverId IN (
+                    re.driverId IN (
                         SELECT DISTINCT driverId
                         FROM results
                         WHERE date > t.timestamp - INTERVAL '1 year'
                     )
-                GROUP BY t.timestamp, dri.driverId
+                GROUP BY t.timestamp, re.driverId
 
             ;
             """
@@ -85,7 +81,7 @@ class DriverDNFTask(EntityTask):
             f"""
                 SELECT
                     t.timestamp as date,
-                    dri.driverId as driverId,
+                    re.driverId as driverId,
                     MAX(CASE WHEN re.statusId != 1 THEN 1 ELSE 0 END) AS did_not_finish
                 FROM
                     timestamp_df t
@@ -94,17 +90,13 @@ class DriverDNFTask(EntityTask):
                 ON
                     re.date <= t.timestamp + INTERVAL '{self.timedelta}'
                     and re.date  > t.timestamp
-                LEFT JOIN
-                    drivers dri
-                ON
-                    re.driverId = dri.driverId
                 WHERE
-                    dri.driverId IN (
+                    re.driverId IN (
                         SELECT DISTINCT driverId
                         FROM results
                         WHERE date > t.timestamp - INTERVAL '1 year'
                     )
-                GROUP BY t.timestamp, dri.driverId
+                GROUP BY t.timestamp, re.driverId
 
             ;
             """
@@ -141,7 +133,7 @@ class DriverTop3Task(EntityTask):
             f"""
                 SELECT
                     t.timestamp as date,
-                    dri.driverId as driverId,
+                    qu.driverId as driverId,
                     CASE
                         WHEN MIN(qu.position) <= 3 THEN 1
                         ELSE 0
@@ -153,17 +145,13 @@ class DriverTop3Task(EntityTask):
                 ON
                     qu.date <= t.timestamp + INTERVAL '{self.timedelta}'
                     and qu.date > t.timestamp
-                LEFT JOIN
-                    drivers dri
-                ON
-                    qu.driverId = dri.driverId
                 WHERE
-                    dri.driverId IN (
+                    qu.driverId IN (
                         SELECT DISTINCT driverId
                         FROM qualifying
                         WHERE date > t.timestamp - INTERVAL '1 year'
                     )
-                GROUP BY t.timestamp, dri.driverId
+                GROUP BY t.timestamp, qu.driverId
 
             ;
             """

--- a/relbench/tasks/f1.py
+++ b/relbench/tasks/f1.py
@@ -22,8 +22,6 @@ class DriverPositionTask(EntityTask):
         timestamp_df = pd.DataFrame({"timestamp": timestamps})
 
         results = db.table_dict["results"].df
-        drivers = db.table_dict["drivers"].df
-        races = db.table_dict["races"].df
 
         df = duckdb.sql(
             f"""
@@ -74,8 +72,6 @@ class DriverDNFTask(EntityTask):
         timestamp_df = pd.DataFrame({"timestamp": timestamps})
 
         results = db.table_dict["results"].df
-        drivers = db.table_dict["drivers"].df
-        races = db.table_dict["races"].df
 
         df = duckdb.sql(
             f"""
@@ -127,7 +123,6 @@ class DriverTop3Task(EntityTask):
         timestamp_df = pd.DataFrame({"timestamp": timestamps})
 
         qualifying = db.table_dict["qualifying"].df
-        drivers = db.table_dict["drivers"].df
 
         df = duckdb.sql(
             f"""


### PR DESCRIPTION
For the F1 tasks, all the SQL's inside `make_table` do a `LEFT JOIN` with `drivers` table. This join is not necessary since the only column accessed from the `drivers` is `driverId`, which already exists in other tables such as `results` and `qualifying`.

I verified that the dataframes produced by `make_table` for all 3 tasks still match the dataframes when specifying `download=True` inside `get_task`.