### PR TITLE
Bump RelBench version in pyproject.toml for PyPI update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "relbench"
-version = "2.0.2"
+version = "2.0.3"
 description = "RelBench: Relational Deep Learning Benchmark"
 authors = [{name = "RelBench Team", email = "relbench@cs.stanford.edu"}]
 readme = "README.md"

--- a/relbench/tasks/__init__.py
+++ b/relbench/tasks/__init__.py
@@ -518,7 +518,7 @@ register_task("rel-ratebeer", "user-beer-favorite", ratebeer.UserFavoriteBeerTas
 
 register_task(
     "rel-ratebeer",
-    "user-beer-rating",
+    "beer_ratings-total_score",
     AutoCompleteTask,
     task_type=TaskType.REGRESSION,
     entity_table="beer_ratings",

--- a/relbench/tasks/hashes.json
+++ b/relbench/tasks/hashes.json
@@ -60,7 +60,7 @@
   "rel-ratebeer/tasks/user-beer-favorite.zip": "610095fff4e33d23e4e23fe3c1a80a295ef76c0648dd67b4e6e7ab0180f7fb2d",
   "rel-ratebeer/tasks/user-place-liked.zip": "c1305b873fbf5092781674cb8d2cb623d203c1f449c9c47e333ac0346ae89c4c",
   "rel-ratebeer/tasks/user-beer-liked.zip": "68fdee4e6297611daabe99ee3a982c3ba8ccab840a6ad0c7d690aecdba318000",
-  "rel-ratebeer/tasks/user-beer-rating.zip": "9ddcecbf3488b19b6ca3fef37f8b28a1b916ae2dd199bac096eb15e47b1a72a3",
+  "rel-ratebeer/tasks/beer_ratings-total_score.zip": "9ddcecbf3488b19b6ca3fef37f8b28a1b916ae2dd199bac096eb15e47b1a72a3",
   "rel-salt/tasks/item-incoterms.zip": "a86919a0cf296d4df745a28206d2832564392d49fc855cd500b1af578b40fbeb",
   "rel-salt/tasks/item-plant.zip": "b2c940aa38a37976934ae48cbb197b909866c60f30f440a49c97d1f73385f771",
   "rel-salt/tasks/item-shippoint.zip": "364f8c0255aad91ecffb55438fd7bfbb6f68c16a92a44c143d0f882ae743c47a",


### PR DESCRIPTION
also update RateBeer autocomplete task name: user-beer-rating -> beer_ratings-total_score (to match autocomplete task naming convention like other datasets' autocomplete tasks)